### PR TITLE
null _imageAssetManager check on Dispose

### DIFF
--- a/LottieUWP/LottieDrawable.cs
+++ b/LottieUWP/LottieDrawable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -858,7 +858,7 @@ namespace LottieUWP
         private void Dispose(bool disposing)
         {
             _animator.Dispose();
-            _imageAssetManager.Dispose();
+            _imageAssetManager?.Dispose();
         }
 
         public void Dispose()


### PR DESCRIPTION
Was encountering the following exception due to the `_imageAssetManager` being null in the `Dispose()` call. 

```
$exception	{System.NullReferenceException: Object reference not set to an instance of an object.
   at LottieUWP.LottieDrawable.Dispose(Boolean disposing)
   at LottieUWP.LottieDrawable.Dispose()
   at LottieUWP.LottieAnimationView.Dispose(Boolean disposing)
   at LottieUWP.LottieAnimationView.Finalize()}	System.NullReferenceException
```
