### PR TITLE
default blend mode for copy operation should be SourceOver

### DIFF
--- a/LottieUWP/Animation/Content/BitmapCanvas.cs
+++ b/LottieUWP/Animation/Content/BitmapCanvas.cs
@@ -282,7 +282,7 @@ namespace LottieUWP.Animation.Content
                 UpdateDrawingSessionWithFlags(renderTargetSave.PaintFlags);
                 CurrentDrawingSession.Transform = GetCurrentTransform();
 
-                var canvasComposite = CanvasComposite.SourceAtop;
+                var canvasComposite = CanvasComposite.SourceOver;
                 if (renderTargetSave.PaintXfermode != null)
                 {
                     canvasComposite = PorterDuff.ToCanvasComposite(renderTargetSave.PaintXfermode.Mode);


### PR DESCRIPTION

This should fix
https://github.com/azchohfi/LottieUWP/issues/4
and the progress bar sample in
https://github.com/azchohfi/LottieUWP/issues/35

After a lot of going in circles, this one line change fixed the mask errors I was having. Of all the blend docs I read this one from QT gave a clear reason why SourceOver should be used.
https://doc.qt.io/archives/qq/qq17-compositionmodes.html
